### PR TITLE
Set QMAILPPID for filters to know grandparent PID.

### DIFF
--- a/README.in
+++ b/README.in
@@ -28,7 +28,8 @@ Requirements:
 How to install:
 
 - Check the definitions at the top of qmail-qfilter.c, especially the
-  value of TMPDIR.  This should be set to a temporary directory that
+  value of TMPDIR.  If you trust mkstemp(3), this can be a world-writable
+  /tmp.  If you don't, this should be set to a temporary directory that
   only the executor of qmail-qfilter has write access to.
 - Check the conf-* files for appropriate values for your compiler and
   linker, and installation paths.

--- a/qmail-qfilter.1
+++ b/qmail-qfilter.1
@@ -47,6 +47,13 @@ returns 0 immediately without running any other filters.
 Otherwise returns the exit code of
 .BR qmail-queue .
 .SH ENVIRONMENT
+.B qmail-qfilter
+sets
+.B QMAILPPID
+to the PID of its parent (e.g.,
+.BR qmail-smtpd )
+so that a filter can log the PID of the session that invoked it.
+.P
 For compatibility with previous versions,
 .B qmail-qfilter
 sets

--- a/qmail-qfilter.1
+++ b/qmail-qfilter.1
@@ -11,13 +11,13 @@ qmail-qfilter \- front end for qmail-queue that does filtering
 .B qmail-qfilter
 sends the message text through each of the filter commands named on
 the command line. 
-Each filter is run seperately, with standard input opened to the input
+Each filter is run separately, with standard input opened to the input
 email, and standard output opened to a new temporary file that will
 become the input to either the next filter, or
 .BR qmail-queue .
 If the filter does not modify the message it passes unchanged to the
 next step.
-It also makes the envelope avaliable to each filter as
+It also makes the envelope available to each filter as
 file descriptor 3.  File descriptor 4 is opened to a new temporary file for the
 modified envelope, allowing the filter to modify the envelope or the
 message.  If the filter does not modify the envelope, the envelope
@@ -30,7 +30,7 @@ also opens up file descriptor 5 to a temporary file.  If this file is
 empty after all the filters have executed, its contents are read and
 used to specify a program to execute in place of
 .BR qmail-queue .
-Each filter on the command line in seperated with
+Each filter on the command line is separated with
 .BR -- .  
 .SH "RETURN VALUES"
 Returns 51 (out of memory), 53 (write error), or 81 (internal error)
@@ -47,7 +47,7 @@ returns 0 immediately without running any other filters.
 Otherwise returns the exit code of
 .BR qmail-queue .
 .SH ENVIRONMENT
-For cmpatibility with previous versions,
+For compatibility with previous versions,
 .B qmail-qfilter
 sets
 .B QMAILUSER
@@ -95,17 +95,17 @@ and
 by using
 .B env -u QMAILNAME -u MAILNAME -u NAME qmail-inject -n
 as the command to invoke qmail-inject.
-Note that some the
+Note that the
 .B env
-command with some OS's doesn't support the
+command with some OSes doesn't support the
 .B -u
 option.
 .P
 A message with an excessive number of recipients (more than 64K bytes of
 recipient data on Linux) will cause execution of the filter programs to
-fail, and for the message to be rejected.
+fail, and the message to be rejected.
 .P
 The same temporary file is reused for file descriptor 5 for each filter.
 Make sure each filter writes a trailing ASCII NUL byte following the
 program name, as multiple filters could otherwise overwrite the value in
-undesireable ways.
+undesirable ways.

--- a/qmail-qfilter.c
+++ b/qmail-qfilter.c
@@ -332,6 +332,8 @@ int main(int argc, char* argv[])
   if ((qqargv[0] = getenv("QQF_QMAILQUEUE")) == 0)
     qqargv[0] = QMAIL_QUEUE;
 
+  mysetenvu("QMAILPPID", getppid());
+
   copy_fd(0, 0, &msg_len);
   copy_fd(1, ENVIN, &env_len);
   parse_envelope();


### PR DESCRIPTION
This PR sets `QMAILPPID` to the PID of its parent (e.g., `qmail-smtpd`) so that a filter can log the PID of the session that invoked it.