### PR TITLE
Adapt to bglibs 2.

### DIFF
--- a/qmail-qfilter.c
+++ b/qmail-qfilter.c
@@ -15,7 +15,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <sysdeps.h>
+#include <bglibs/sysdeps.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
My cross-platform (Linux, NetBSD, OS X, many others) pkgsrc package of qmail-qfilter also has a patch to the `Makefile` included with the distribution. I don't see how the `Makefile` gets generated, so I'm including the patch inline here. In addition to adapting for bglibs 2, it also performs the dynamic linking more portably.

```
--- Makefile.orig	2005-08-12 23:40:51.000000000 +0000
+++ Makefile
@@ -37,7 +37,7 @@ load: conf-ld conf-bglibs
 	( bglibs=`head -n 1 conf-bglibs`; \
 	  echo '#!/bin/sh';\
 	  echo 'main="$$1"; shift';\
-	  echo exec `head -n 1 conf-ld` -L. "-L'$${bglibs}'" '-o "$$main" "$$main.o" $${1+"$$@"}' -lbg-sysdeps; \
+	  echo exec `head -n 1 conf-ld` -L. "-L'$${bglibs}'" "-Wl,-R'$${bglibs}'" '-o "$$main" "$$main.o" $${1+"$$@"}'; \
 	) >load
 	chmod 755 load
```