### PR TITLE
avoid truncation of envelope offset

### DIFF
--- a/qmail-qfilter.c
+++ b/qmail-qfilter.c
@@ -105,7 +105,7 @@ size_t parse_sender(const char* env)
   return ptr + len + 1 - env;
 }
 
-void parse_rcpts(const char* env, int offset)
+void parse_rcpts(const char* env, size_t offset)
 {
   size_t len = env_len - offset;
   const char* ptr = env + offset;


### PR DESCRIPTION
While it is unlikely that the the sender is longer than 2 GiB there is nothing in parse_sender() that enforces this. Since all other code uses size_t anyway there is no point in truncating this only in the API of one function.